### PR TITLE
bugfix: reroute REST plugin link to correct page

### DIFF
--- a/content/docs/manual/plugins.md
+++ b/content/docs/manual/plugins.md
@@ -21,5 +21,5 @@ This automatic search and load of plugins can be desactivated using the `--plugi
 And some plugins library files to load anyway can be specified using the `--plugin` option (repeatable). In such case, the complete path of the library file must be specified, and its filename is free.
 
 Zenoh already provides the following plugins:
- - the [REST plugin](../plugin-rest): providing the zenoh REST API
+ - the [REST plugin](../plugin-http): providing the zenoh REST API
  - the [Storages plugin](../plugin-storages): providing management of [storages](../abstractions#storage) and [backends](../abstractions#backend)


### PR DESCRIPTION
- There is no `plugin-rest` page. Upon clicking the REST plugin user is routed to 404
- Assuming that the REST plugin page is to be routed to subsequent __REST PLUGIN_ page
   set the correct link