### PR TITLE
Typo & 404 fixes

### DIFF
--- a/content/docs/getting-started/quick-test.md
+++ b/content/docs/getting-started/quick-test.md
@@ -105,5 +105,5 @@ Now you can see how to [build your first zenoh application in Python](../first-a
 ## Pick your programming language
 
 If you prefer, you could also have a look to the `examples/zenoh` directory we provide in each zenoh API:
-- [Rust examples](https://github.com/eclipse-zenoh/zenoh/tree/master/zenoh/examples/zenoh)
-- [Python examples](https://github.com/eclipse-zenoh/zenoh-python/tree/master/examples/zenoh)
+- [Rust examples](https://github.com/eclipse-zenoh/zenoh/tree/master/examples)
+- [Python examples](https://github.com/eclipse-zenoh/zenoh-python/tree/master/examples)

--- a/content/docs/overview.md
+++ b/content/docs/overview.md
@@ -20,7 +20,7 @@ data in movement, data at rest and computation in a scalable, efficient and loca
 
 - Give total control on storage location and back-end technology integration.
 
-- Minimize network overhead – the minimal wire overhead of a data message a data message is 4 bytes.
+- Minimize network overhead – the minimal wire overhead of a data message is 4 bytes.
 
 - Support extremely constrained devices – its footprint on Arduino Uno is of 300 bytes.
 

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -56,7 +56,7 @@
     <p>
         <b>Evaluations</b><br>
         zenoh allows applications to register computations that will be
-        triggered by queries. A simple mechanism that allows many pattern
+        triggered by queries. A simple mechanism that allows many patterns
         to be implemented, such as RPC and map-reduce.
       </p>
 
@@ -114,7 +114,7 @@
     <p>
       <b>Fast Adoption</b><br>
       zenoh has a very simple API that makes it extremely fast to get started 
-      and productive. API are available for the most popular programming languages 
+      and productive. APIs are available for the most popular programming languages
       and more are added regularly.
     <p>
 
@@ -125,7 +125,7 @@
     </p>
     <p>
       <b>High Throughput</b><br>
-      zenoh delivers extremely high throughput and allow you to further 
+      zenoh delivers extremely high throughput and allows you to further
       its off-the-shelf performance through the batching API.
     </p>
     <hr class="half-rule">


### PR DESCRIPTION
I saw a bunch of typos and 404 links while going through the documentation.