### PR TITLE
Fix the nonclosed rawHtml tags

### DIFF
--- a/content/adopters.md
+++ b/content/adopters.md
@@ -94,4 +94,4 @@ Below is a list of companies, research institutes and foundations that adopted, 
     </div>
 </div>
 <p></p>
-
+{{< /rawhtml >}}

--- a/content/usecases.md
+++ b/content/usecases.md
@@ -49,3 +49,4 @@ menu:
         <iframe src="https://www.youtube.com/embed/rNTY3nxcpc8" width="320" height="240" allow="autoplay"></iframe>
     </div>
 </div>
+{{< /rawhtml >}}


### PR DESCRIPTION
Although we fix the version of Hugo to 0.102.1, my latest Hugo (v0.111.3+) complains about the incomplete tag of `rawHtml`.  Hence, this PR is submitted to fix it.