### PR TITLE
Adding link to Pico API docs

### DIFF
--- a/content/docs/APIs/Pico.md
+++ b/content/docs/APIs/Pico.md
@@ -1,0 +1,12 @@
+---
+title: "Pico API"
+weight: 4225
+menu:
+  docs:
+    parent: APIs
+---
+
+{{< rawhtml >}}
+The Pico API documentation is available on 
+<a href="https://zenoh-pico.readthedocs.io/" target="_blank">Read the Docs</a>.
+{{< /rawhtml >}}


### PR DESCRIPTION
I added a link to Zenoh-pico's API docs.