### PR TITLE
docs: update getting-started/first-app to be in line with current python API

### DIFF
--- a/content/docs/getting-started/first-app.md
+++ b/content/docs/getting-started/first-app.md
@@ -54,7 +54,7 @@ Now we need a subscriber, `z_subscriber.py` that can receive the measurements:
 import zenoh, time
 
 def listener(sample):
-    print(f"Received {sample.kind} ('{sample.key_expr}': '{sample.payload.deserialize(str)}')")
+    print(f"Received {sample.kind} ('{sample.key_expr}': '{sample.payload.to_string()}')")
     
 if __name__ == "__main__":
     session = zenoh.open(zenoh.Config())
@@ -119,10 +119,10 @@ if __name__ == "__main__":
     for reply in replies:
         try:
             print("Received ('{}': '{}')"
-                .format(reply.ok.key_expr, reply.ok.payload.deserialize(str)))
+                .format(reply.ok.key_expr, reply.ok.payload.to_string()))
         except:
             print("Received (ERROR: '{}')"
-                .format(reply.err.payload.decode(str)))
+                .format(reply.err.payload.to_string()))
 
 session.close()
 ```


### PR DESCRIPTION
The getting-started/first-app guide is broken as it seems to not have been updated to the current python API in `1.0.0-*` since beta4. I updated the code blocks as documented in the python examples.