### PR TITLE
chore: correct doc to save key in binary format

### DIFF
--- a/content/docs/getting-started/installation.md
+++ b/content/docs/getting-started/installation.md
@@ -53,7 +53,7 @@ $ zenohd
 Add Eclipse Zenoh public key to apt keyring
 
 ```bash
-$ curl -L https://download.eclipse.org/zenoh/debian-repo/zenoh-public-key | sudo tee /etc/apt/keyrings/zenoh-public-key.gpg
+$ curl -L https://download.eclipse.org/zenoh/debian-repo/zenoh-public-key | sudo gpg --dearmor --yes --output /etc/apt/keyrings/zenoh-public-key.gpg
 ```
 
 Add Eclipse Zenoh private repository to the sources list:


### PR DESCRIPTION
According to debian docs: https://wiki.debian.org/SecureApt#How_to_find_and_add_a_key, in the "Adding an external repository" section, the key should be converted to binary format 